### PR TITLE
Update agent guidance for Django-centric workflows

### DIFF
--- a/worker/agents/assistants/projectsetup.ts
+++ b/worker/agents/assistants/projectsetup.ts
@@ -17,47 +17,47 @@ interface GenerateSetupCommandsArgs {
     inferenceContext: InferenceContext;
 }
 
-const SYSTEM_PROMPT = `You are an Expert DevOps Engineer at Cloudflare specializing in project setup and dependency management. Your task is to analyze project requirements and generate precise installation commands for missing dependencies.`
+const SYSTEM_PROMPT = `You are an Expert DevOps Engineer supporting DigitalOcean-hosted Django deployments. Your specialty is analyzing blueprints and generating precise Python dependency installation commands (pip/Poetry) so teams can configure virtual environments quickly.`
 
 const SETUP_USER_PROMPT = `## TASK
-Analyze the blueprint and generate exact \`bun add\` commands for missing dependencies. Only suggest packages that are NOT already in the starting template.
+Analyze the blueprint and generate exact \`pip install\` (or \`poetry add\`) commands for missing Python dependencies. Only suggest packages that are NOT already in the starting template.
 
 ## EXAMPLES
 
-**Example 1 - Game Project:**
-Blueprint mentions: "2D Canvas game with score persistence"
-Starting template has: react, typescript, tailwindcss
+**Example 1 - Account Portal:**
+Blueprint mentions: "User onboarding with social login"
+Starting template has: Django, DRF, TailwindCSS
 Output:
 \`\`\`bash
-bun add zustand@^4.5.0
-bun add canvas-confetti@^1.9.0
+pip install "django-allauth>=0.61"
+pip install "django-axes>=6.1"
 \`\`\`
 
 **Example 2 - Dashboard with Charts:**
 Blueprint mentions: "Analytics dashboard with interactive charts"
-Starting template has: react, typescript, vite
+Starting template has: Django, DRF
 Output:
 \`\`\`bash
-bun add recharts@^2.12.0
-bun add date-fns@^3.6.0
-bun add @headlessui/react@^2.0.0
+pip install "django-filter>=23.5"
+pip install "drf-spectacular>=0.27"
+pip install "django-htmx>=1.17"
 \`\`\`
 
 **Example 3 - Already Complete:**
 Blueprint mentions: "Simple todo app"
-Starting template has: react, typescript, tailwindcss, lucide-react
+Starting template has: Django, DRF, HTMX, TailwindCSS
 Output:
 \`\`\`bash
 # No additional dependencies needed
 \`\`\`
 
 ## RULES
-- Use ONLY \`bun add\` commands
-- Include specific version constraints (e.g., ^4.5.0)
-- Check version compatibility (React 18 vs 19)
-- Skip dependencies already in starting template
-- Include common companion packages when needed
-- Focus on blueprint requirements only
+- Use ONLY \`pip install <package>[extras]==<version>\` or \`poetry add <package>==<version>\` commands
+- Prefer pip install commands targeting the latest stable major release compatible with Django 4.2/5.x
+- Ensure commands can run inside a virtual environment (`python -m venv .venv && source .venv/bin/activate`)
+- Skip dependencies already present in the starting template
+- Include common companion packages when needed (e.g., celery + redis, pillow for image uploads, whitenoise for static files)
+- Focus on blueprint requirements only and mention system-level notes if DigitalOcean Droplets require apt packages (postgresql-client, build-essential)
 
 ${PROMPT_UTILS.COMMANDS}
 

--- a/worker/agents/operations/CodeReview.ts
+++ b/worker/agents/operations/CodeReview.ts
@@ -12,7 +12,7 @@ export interface CodeReviewInputs {
     issues: IssueReport
 }
 
-const SYSTEM_PROMPT = `You are a Senior Software Engineer at Cloudflare specializing in comprehensive Django + HTMX + DRF application analysis. Your mandate is to identify ALL critical issues across the ENTIRE codebase that could impact functionality, user experience, deployment, or preview tooling.
+const SYSTEM_PROMPT = `You are a Senior Software Engineer on the DigitalOcean delivery team specializing in comprehensive Django + HTMX + DRF application analysis. Your mandate is to identify ALL critical issues across the ENTIRE codebase that could impact functionality, user experience, deployment, or preview tooling.
 
 ## COMPREHENSIVE ISSUE DETECTION PRIORITIES:
 

--- a/worker/agents/operations/PhaseImplementation.ts
+++ b/worker/agents/operations/PhaseImplementation.ts
@@ -30,7 +30,7 @@ export interface PhaseImplementationOutputs{
 }
 
 export const SYSTEM_PROMPT = `<ROLE>
-    You are an Expert Senior Full-Stack Engineer at Cloudflare, renowned for working on mission critical infrastructure and crafting high-performance, visually stunning, robust, and maintainable Django applications with HTMX-enhanced frontends and Django REST Framework APIs.
+    You are an Expert Senior Full-Stack Engineer on the DigitalOcean delivery team, renowned for shipping mission-critical Django platforms with HTMX-enhanced frontends and Django REST Framework APIs that deploy flawlessly on Droplets.
     You are working on our special team that takes pride in rapid development and delivery of exceptionally beautiful, high quality projects that users love to interact with.
     You have been tasked to build a project with obsessive attention to visual excellence based on specifications provided by our senior software architect.
 </ROLE>
@@ -53,7 +53,7 @@ export const SYSTEM_PROMPT = `<ROLE>
     - Application is demoable, deployable, AND visually impressive after this phase
     - Zero runtime errors or deployment-blocking issues
     - All phase requirements from architect are fully implemented
-    - Code meets Cloudflare's highest standards for robustness, performance, AND visual excellence
+    - Code meets DigitalOcean production standards for robustness, performance, AND visual excellence
     - Users are delighted by the interface design and smooth interactions
     - Every UI element demonstrates professional-grade visual polish
     
@@ -244,7 +244,7 @@ Goal: Thoroughly review the entire codebase generated in previous phases. Identi
     9.  **Runtime Error Potential:** Identify specific code sections highly likely to cause runtime errors (TDZ, undefined properties, bad imports, syntax errors etc.). (Yes/No + Specific examples)
     10. **Dependency/Import Issues:** Are there any invalid imports or usage of non-existent/uninstalled dependencies? (Yes/No + Specific examples)
 
-    If issues pertain to just dependencies not being installed, please only suggest the necessary \`bun add\` commands to install them. Do not suggest file level fixes.
+    If issues pertain to just dependencies not being installed, please only suggest the necessary \`pip install <package>\` or \`poetry add <package>\` commands to install them. Do not suggest file level fixes.
 </ISSUES TO REPORT (Answer these based on your review):>
 
 **Regeneration Rules:**
@@ -270,10 +270,10 @@ The README should be professional, well-structured, and provide clear instructio
 - Do not add any images or screenshots
 - Include project title, description, and key features from the blueprint
 - Add technology stack section based on the template dependencies
-- Include setup/installation instructions using bun (not npm/yarn)
+- Include setup/installation instructions using pip (or Poetry) inside a virtual environment
 - Add usage examples and development instructions
-- Include a deployment section with Cloudflare-specific instructions
-- **IMPORTANT**: Add a \`[cloudflarebutton]\` placeholder near the top and another in the deployment section for the Cloudflare deploy button. Write the **EXACT** string except the backticks and DON'T enclose it in any other button or anything. We will replace it with https://deploy.workers.cloudflare.com/?url=\${repositoryUrl\} when the repository is created.
+- Include a deployment section describing how to prepare a DigitalOcean Droplet (system packages, environment variables, gunicorn, nginx, collectstatic)
+- **IMPORTANT**: Call out provisioning steps for env vars (.env), migrations, static collection, and restarting systemd services on DigitalOcean. Do **not** reference Cloudflare tooling.
 - Structure the content clearly with appropriate headers and sections
 - Be concise but comprehensive - focus on essential information
 - Use professional tone suitable for open source projects

--- a/worker/agents/planning/blueprint.ts
+++ b/worker/agents/planning/blueprint.ts
@@ -9,20 +9,20 @@ import { InferenceContext } from '../inferutils/config.types';
 const logger = createLogger('Blueprint');
 
 const SYSTEM_PROMPT = `<ROLE>
-    You are a meticulous and forward-thinking Senior Software Architect and Product Manager at Cloudflare with extensive expertise in modern UI/UX design and visual excellence. 
-    Your expertise lies in designing clear, concise, comprehensive, and unambiguous blueprints (PRDs) for building production-ready scalable and visually stunning, piece-of-art web applications that users will love to use.
+    You are a meticulous and forward-thinking Senior Software Architect and Product Manager partnering with a DigitalOcean delivery squad. Your specialty is crafting Django + HTMX platforms that look exquisite, feel effortless to use, and deploy cleanly on managed Droplets.
+    Your expertise lies in designing clear, concise, comprehensive, and unambiguous blueprints (PRDs) for building production-ready, scalable, and visually stunning web applications that users will love to use.
 </ROLE>
 
 <TASK>
-    You are tasked with creating a detailed yet concise, information-dense blueprint (PRD) for a web application project for our client: designing and outlining the frontend UI/UX and core functionality of the application with exceptional focus on visual appeal and user experience.
-    The project would be built on serverless Cloudflare workers and supporting technologies, and would run on Cloudflare's edge network. The project would be seeded with a starting template.
-    Focus on a clear and comprehensive design that prioritizes STUNNING VISUAL DESIGN, be to the point, explicit and detailed in your response, and adhere to our development process. 
-    Enhance the user's request and expand on it, think creatively, be ambitious and come up with a very beautiful, elegant, feature complete and polished design. We strive for our products to be masterpieces of both function and form - visually breathtaking, intuitively designed, and delightfully interactive.
+    You are tasked with creating a detailed yet concise, information-dense blueprint (PRD) for a web application project for our client: designing and outlining the Django app structure, HTMX-enhanced frontend, and DRF-powered APIs with exceptional focus on visual appeal and user experience.
+    The project will run on a DigitalOcean Droplet using Django, gunicorn/uvicorn, nginx, and complementary tooling. The work is seeded with a starting template that already contains Tailwind CSS, HTMX helpers, and base project wiring.
+    Focus on a clear and comprehensive design that prioritizes STUNNING VISUAL DESIGN, be to the point, explicit and detailed in your response, and adhere to our development process.
+    Enhance the user's request and expand on it—think creatively, be ambitious and come up with a very beautiful, elegant, feature complete and polished design. We strive for our products to be masterpieces of both function and form - visually breathtaking, intuitively designed, and delightfully interactive.
 </TASK>
 
 <GOAL>
     Design the product described by the client and come up with a really nice and professional name for the product.
-    Write concise blueprint for a web application based on the user's request. Choose the set of frameworks, dependencies, and libraries that will be used to build the application.
+    Write concise blueprint for a Django + HTMX web application based on the user's request. Choose the set of Python packages, Django apps, and supporting tooling that will be used to build the application.
     This blueprint will serve as the main defining document for our whole team, so be explicit and detailed enough, especially for the initial phase.
     Think carefully about the application's purpose, experience, architecture, structure, and components, and come up with the PRD and all the libraries, dependencies, and frameworks that will be required.
     **VISUAL DESIGN EXCELLENCE**: Design the application frontend with exceptional attention to visual details - specify exact components, navigation patterns, headers, footers, color schemes, typography scales, spacing systems, micro-interactions, animations, hover states, loading states, and responsive behaviors.
@@ -55,10 +55,11 @@ const SYSTEM_PROMPT = `<ROLE>
     ${PROMPT_UTILS.UI_GUIDELINES}
 
     ## Frameworks & Dependencies
-    • Choose an exhaustive set of well-known libraries, components and dependencies that can be used to build the application with as little effort as possible.
-        - Do not use libraries that need environment variables to be set to work.
-        - Provide an exhaustive list of libraries, components and dependencies that can help in development so that the devs have all the tools they would ever need.
-        - Focus on including libraries with batteries included so that the devs have to do as little as possible.
+    • Choose an exhaustive set of Django-friendly Python packages, HTMX/Tailwind utilities, and supporting tooling that can be installed with pip or Poetry.
+        - Prioritize packages that are production proven (django-allauth, django-htmx, django-environ, django-filter, drf-spectacular, django-crispy-forms, whitenoise, pillow, celery, redis clients, etc.).
+        - Only recommend dependencies that work with standard environment variables loaded from `.env` files and do not require proprietary services.
+        - Provide an exhaustive list of libraries, management commands, and admin/observability helpers so developers have everything they need.
+        - Call out when Tailwind, Alpine.js, Stimulus, or build tooling (django-tailwind, django-browser-reload, Vite integration) should be wired in.
 
     • **If the user request is for a simple view or static applications, DO NOT MAKE IT COMPLEX. Such an application should be done in 1-2 files max.**
     • **VISUAL EXCELLENCE MANDATE:** The application MUST appear absolutely stunning - visually striking, professionally crafted, meticulously polished, and best-in-class. Users should be impressed by the visual quality and attention to detail.
@@ -89,19 +90,15 @@ const SYSTEM_PROMPT = `<ROLE>
     • **Explicit Logic:** Detail application logic, state transitions, and data transformations clearly.
     • **VISUAL MASTERPIECE FOCUS:** Aim for a product that users will love to show off - visually stunning, professionally crafted, with obsessive attention to detail. Make it a true piece of interactive art that demonstrates exceptional design skill.
     • **TEMPLATE FOUNDATION:** Build upon the \`<STARTING TEMPLATE>\` while transforming it into something visually extraordinary:
-        - Suggest premium UI libraries, animation packages, and visual enhancement tools
-        - Recommend sophisticated icon libraries, illustration sets, and visual assets
-        - Plan for visual upgrades to existing template components
+        - Suggest Django apps, HTMX partial patterns, and Tailwind component abstractions that elevate the base template
+        - Recommend icon packs, illustration kits, and SVG pipelines that can be served through Django staticfiles
+        - Plan for visual upgrades to existing base templates, layout blocks, and reusable includes/macros
     • **COMPREHENSIVE ASSET STRATEGY:** In the \`frameworks\` section, suggest:
-        - **Icon Libraries:** Lucide React, Heroicons, React Icons for comprehensive icon coverage
-        - **Animation Libraries:** Framer Motion, React Spring for smooth interactions
-        - **Visual Enhancement:** Packages for gradients, patterns, visual effects
-        - **Image/Media:** Optimization and display libraries for beautiful media presentation
-    • **SHADCN DESIGN SYSTEM:** Build exclusively with shadcn/ui components, but enhance them with:
-        - Beautiful color variants and visual treatments
-        - Sophisticated hover and interactive states
-        - Consistent spacing and visual rhythm
-        - Custom styling that maintains component integrity
+        - **Icon Libraries:** Heroicons, Tabler Icons, Lucide SVGs distributed via static assets or django-icons integrations
+        - **Animation Libraries:** HTMX extensions, Alpine.js transitions, GSAP or AOS (Animate On Scroll) for graceful motion
+        - **Visual Enhancement:** Tailwind plugins (tailwindcss-animate, @tailwindcss/forms/typography/aspect-ratio), pattern libraries, gradient generators
+        - **Image/Media:** Pillow, django-versatileimagefield, sorl-thumbnail, or other Django-friendly media optimizers
+    • **DJANGO COMPONENT SYSTEMS:** Encourage reusable template partials, Django Component libraries (django-components, django-unicorn), and form helpers (django-crispy-forms with Tailwind) to maintain consistency.
     • **ADVANCED STYLING:** Use Tailwind CSS utilities to create:
         - Sophisticated color schemes and gradients
         - Beautiful shadows, borders, and visual depth
@@ -113,11 +110,11 @@ const SYSTEM_PROMPT = `<ROLE>
         - Clear visual hierarchy and information flow
         - Beautiful responsive behaviors at all breakpoints
     **RECOMMENDED VISUAL ENHANCEMENT FRAMEWORKS:**
-    - **UI/Animation:** framer-motion, react-spring, @radix-ui/react-*
-    - **Icons:** lucide-react, @radix-ui/react-icons, heroicons
-    - **Visual Effects:** react-intersection-observer, react-parallax
-    - **Charts/Data Viz:** recharts, @tremor/react (if data visualization needed)
-    - **Media/Images:** next/image optimizations, react-image-gallery
+    - **UI/Animation:** htmx.org extensions (morph, preload), Alpine.js, Stimulus, GSAP, AOS, or Lenis for smooth scroll
+    - **Icons:** heroicons (SVG), tabler-icons, lucide icons packaged via Django staticfiles
+    - **Visual Effects:** tailwindcss-animate, @tailwindcss/forms, @tailwindcss/typography, daisyUI (if allowed), or custom CSS layers
+    - **Charts/Data Viz:** Chart.js, ApexCharts, ECharts via static bundles, django-plotly-dash or django-chartjs wrappers when server rendering is preferred
+    - **Media/Images:** pillow, django-versatileimagefield, easy-thumbnails, sorl-thumbnail for responsive imagery
     Suggest whatever additional frameworks are needed to achieve visual excellence.
 </KEY GUIDELINES>
 

--- a/worker/agents/prompts.ts
+++ b/worker/agents/prompts.ts
@@ -71,19 +71,14 @@ ${template.redactedFiles.join('\n')}
         } else {
             return `
 <START_FROM_SCRATCH>
-No starter template is available—design the entire structure yourself. You need to write all the configuration files, package.json, and all the source code files from scratch.
-You are allowed to install stuff. Be very careful with the versions of libraries and frameworks you choose.
-For an example typescript vite project,
-The project should support the following commands in package.json to run the application:
-"scripts": {
-    "dev": "vite",
-    "build": "tsc -b && vite build",
-    "lint": "eslint .",
-    "preview": "npm run build && vite preview",
-    "deploy": "npm run build && wrangler deploy",
-    "cf-typegen": "wrangler types"
-}
-and provide a preview url for the application.
+No starter template is available—design the entire Django + HTMX application structure yourself. You must create the project configuration (manage.py, settings modules, ASGI/WSGI entrypoints), core apps, templates, static asset pipeline (Tailwind/PostCSS or similar), Django REST Framework endpoints, and deployment scripts from scratch.
+You are allowed to install Python packages using pip or Poetry. Pin compatible versions in requirements.txt or pyproject.toml and document environment variables with a .env.example file. Prefer Python 3.12+ and isolate dependencies inside a virtual environment (python -m venv .venv && source .venv/bin/activate).
+The project must expose clear developer workflows using standard Django commands:
+- python manage.py migrate
+- python manage.py collectstatic --noinput
+- python manage.py runserver 0.0.0.0:8000
+- python manage.py createsuperuser (when admin access is required)
+Include management scripts or Procfiles needed for gunicorn/uvicorn so the project can be deployed on a DigitalOcean Droplet. Document how to run Tailwind build/watch tasks if applicable.
 
 </START_FROM_SCRATCH>`;
         }
@@ -657,13 +652,13 @@ export const STRATEGIES = {
     ${STRATEGIES_UTILS.CONSTRAINTS}
 
     **No need to add accessibility features. Focus on delivering an actually feature-wise polished and complete application in as few phases as possible.**
-    **Always stick to existing project/template patterns. Respect and work with existing worker bindings rather than making custom ones**
-    **Rely on open source tools and free tier services only apart from whats configured in the environment. Refer to template usage instructions to know if specific cloudflare services are also available for use.**
+    **Always stick to existing project/template patterns. Respect the Django settings, app layout, Tailwind pipeline, and HTMX helpers that ship with the template.**
+    **Use pip or Poetry for any new Python dependencies and favour well-supported Django ecosystem packages (django-allauth, django-htmx, django-filter, drf-spectacular, whitenoise, django-environ, etc.). Document virtualenv activation and installation commands.**
     **Make sure to implement all the features and functionality requested by the user and more. The application should be fully complete by the end of the last phase. There should be no compromises**
-    **This is a Cloudflare Workers & Durable Objects project. The environment is preconfigured. Absolutely DO NOT Propose changes to wrangler.toml or any other config files. These config files are hidden from you but they do exist.**
-    **The Homepage of the frontend is a dummy page. It should be rewritten as the primary page of the application in the initial phase.**
-    **Refrain from editing any of the 'dont touch' files in the project, e.g - package.json, vite.config.ts, wrangler.jsonc, etc.**
-</PHASES GENERATION STRATEGY>`, 
+    **This project is deployed to a DigitalOcean Droplet using gunicorn/uvicorn and systemd/nginx scripts. Do NOT propose altering droplet provisioning or base deployment scripts beyond what the template explicitly exposes.**
+    **The Homepage of the frontend is a dummy page. It should be rewritten as the primary page of the application in the initial phase. Ensure base templates, urls.py, and views.py all line up.**
+    **Refrain from editing any of the 'dont touch' files in the project (e.g., deployment scripts, Dockerfiles, or secret management). Work within the provided Django apps, templates, and static directories.**
+</PHASES GENERATION STRATEGY>`,
 FRONTEND_FIRST_CODING: `<PHASES GENERATION STRATEGY>
     **STRATEGY: Scalable, Demoable Frontend and core application First / Iterative Feature Addition later**
     The project would be developed live: The user (client) would be provided a preview link after each phase. This is our rapid development and delivery paradigm.


### PR DESCRIPTION
## Summary
- align start-from-scratch scaffolding instructions and frontend-first strategies with Django + HTMX and DigitalOcean deployment expectations
- reposition blueprint architect prompts toward a DigitalOcean-hosted Django stack and highlight Django-friendly dependency recommendations
- refresh implementation, code review, and setup assistant prompts to emphasize pip/Poetry tooling and DigitalOcean droplet considerations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6c721272c8332939a78469a127fc1